### PR TITLE
Only add the TMDB id to cache if a file was downloaded

### DIFF
--- a/root/scripts/download.bash
+++ b/root/scripts/download.bash
@@ -414,7 +414,9 @@ DownloadTrailers () {
 		fi
 		
 		echo "$currentprocessid of $radarrmovietotal :: $radarrmovietitle :: $trailercount Extras Downloaded!"
-		touch "/config/cache/${themoviedbmovieid}-complete"
+		if [ "$trailercount" -ne "0" ]; then
+			touch "/config/cache/${themoviedbmovieid}-complete"
+		fi
 	done
 	if [ "$USEFOLDERS" == "true" ]; then
 		trailercount="$(find "$radarrmovierootpath" -mindepth 3 -type f -iname "*.mkv" | wc -l)"


### PR DESCRIPTION
I was getting alot of 429 errors from youtube-dl, however the script still adds the %tmdbid%-complete file in the cache after a failure. As a result, subsequent script runs would ignore those movies until I manually delete the incorrect cache files.